### PR TITLE
fix: Crafting error when opening

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -32,7 +32,7 @@ Config.AttachmentCrafting = {
             points = 2,
         },
         [3] = {
-            name = "rifle_extendedclip",
+            name = "assaultrifle_extendedclip",
             amount = 50,
             info = {},
             costs = {
@@ -47,7 +47,7 @@ Config.AttachmentCrafting = {
             points = 8,
         },
         [4] = {
-            name = "rifle_drummag",
+            name = "assaultrifle_drum",
             amount = 50,
             info = {},
             costs = {
@@ -62,7 +62,7 @@ Config.AttachmentCrafting = {
             points = 8,
         },
         [5] = {
-            name = "smg_flashlight",
+            name = "smg_drum",
             amount = 50,
             info = {},
             costs = {
@@ -90,7 +90,7 @@ Config.AttachmentCrafting = {
             points = 4,
         },
         [7] = {
-            name = "smg_suppressor",
+            name = "microsmg_extendedclip",
             amount = 50,
             info = {},
             costs = {


### PR DESCRIPTION
Item names were changed when the attachment update rolled out so it threw an error when trying to open it. There was also no `smg_flashlight` and `smg_suppressor` items anymore so I just replaced them with other SMG attachments for now

Goes with https://github.com/qbcore-framework/qb-inventory/pull/66